### PR TITLE
Use `librlimit` to infer open file limit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,9 @@ set(name pear-runtime)
 
 project(${name} C)
 
-fetch_package("github:holepunchto/bare@1.15.2")
+fetch_package("github:holepunchto/bare@1.16.2")
 fetch_package("github:holepunchto/libpath")
+fetch_package("github:holepunchto/librlimit")
 
 bare_target(target)
 
@@ -43,6 +44,7 @@ target_link_libraries(
   ${name}_obj
   PUBLIC
     path
+    rlimit
 )
 
 add_executable(${name}_bin)
@@ -60,6 +62,7 @@ target_link_libraries(
     ${name}_obj
   PRIVATE
     path_static
+    rlimit_static
     $<LINK_LIBRARY:WHOLE_ARCHIVE,bare_static>
 )
 

--- a/src/main.c
+++ b/src/main.c
@@ -1,6 +1,8 @@
 #include <assert.h>
 #include <bare.h>
 #include <path.h>
+#include <rlimit.h>
+#include <stddef.h>
 #include <string.h>
 #include <uv.h>
 
@@ -13,6 +15,9 @@
 int
 main (int argc, char *argv[]) {
   int err;
+
+  err = rlimit_set(rlimit_open_files, rlimit_infer);
+  assert(err == 0);
 
   argv = uv_setup_args(argc, argv);
 


### PR DESCRIPTION
Also bumps Bare to v1.16.2.